### PR TITLE
Export custom overlay data

### DIFF
--- a/frontend/common/map.js
+++ b/frontend/common/map.js
@@ -100,6 +100,12 @@ fetch("layers.json")
 						});
 				}
 				const tiles = data["tilelayer"]
+				const overlaydata = data["overlay"]
+				const overlay = L.tileLayer (
+						overlaydata["url_template"],
+						{
+							opacity: overlay["opacity"]
+						});
 				const osm = L.tileLayer(
 						tiles["url_template"],
 						{
@@ -114,7 +120,8 @@ fetch("layers.json")
 						maxZoom: 19,
 						paintRules: rules,	
 				});
-				osm.addTo(map);
+				baseLayer = L.layerGroup([osm, overlay]);
+				baseLayer.addTo(map);
 				legend.addTo(map);
 				strecken.addTo(map);
 				if ("points_url" in data) {

--- a/frontend/common/map.js
+++ b/frontend/common/map.js
@@ -110,7 +110,7 @@ fetch("layers.json")
 						}
 				);
 				baseLayer.addLayer(osm);
-				if (overlaydata) {
+				if (overlaydata["url_template"] != null) {
 						 const overlay = L.tileLayer (
 							overlaydata["url_template"],
 							{

--- a/frontend/common/map.js
+++ b/frontend/common/map.js
@@ -101,11 +101,7 @@ fetch("layers.json")
 				}
 				const tiles = data["tilelayer"]
 				const overlaydata = data["overlay"]
-				const overlay = L.tileLayer (
-						overlaydata["url_template"],
-						{
-							opacity: overlay["opacity"]
-						});
+				const baseLayer = L.layerGroup([])
 				const osm = L.tileLayer(
 						tiles["url_template"],
 						{
@@ -113,6 +109,15 @@ fetch("layers.json")
 								attribution: tiles["attribution"]
 						}
 				);
+				baseLayer.addLayer(osm);
+				if (overlaydata) {
+						 const overlay = L.tileLayer (
+							overlaydata["url_template"],
+							{
+								opacity: overlaydata["opacity"]
+							})
+							baseLayer.addLayer(overlay)
+							};
 				const strecken = protomapsL.leafletLayer({
 						attribution: "",
 						url: data["pmtiles_url"] ?? "strecken.pmtiles",
@@ -120,7 +125,6 @@ fetch("layers.json")
 						maxZoom: 19,
 						paintRules: rules,	
 				});
-				baseLayer = L.layerGroup([osm, overlay]);
 				baseLayer.addTo(map);
 				legend.addTo(map);
 				strecken.addTo(map);

--- a/scripts/umap-extractor.py
+++ b/scripts/umap-extractor.py
@@ -35,6 +35,7 @@ config = {}
 config["name"] = properties["name"]
 colors = {}
 config["layers"] = colors
+config["overlay"] = properties["overlay"]
 
 if "tilelayer" in properties and properties['tilelayer'] != {} :
     config["tilelayer"] = properties["tilelayer"]


### PR DESCRIPTION
I'm using a custom overlay to display the OpenRailwayMap on top of the OSM map. This PR enables the export of the overlay properties from umap by merging the existing osm layer with an overlay layer into a layer group. The osm layer has to be added to the layer group first so that the overlay is set "on top". When no overlay template is found (checked through "template_url"), the layer group just consits of the osm layer. 

<img width="911" height="463" alt="grafik" src="https://github.com/user-attachments/assets/98ef0620-5f3f-4074-98cd-838aec912f7f" />

(I'm a JavaScript novice so feel free to add to the commits if they need further refinement)