### PR TITLE
Added multifolder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ map when the map data is pushed.
 #### Input Data
 
 The input folder for `strecken.pmtiles` consists of a `data/` folder,
-with one subfolder for each layer. In each of these folders, the lines
+with one subfolder for each layer. In each of these layer folders the lines
 to be displayed on the map can be deposited in any format understood
 by [ogrmerge](https://gdal.org/programs/ogrmerge.html), for instance,
 GeoJSON or gpx. The input data can be obtained from OpenStreetMap
-using tools such as [brouter][brouter] or [osmexp][osmexp].
+using tools such as [brouter][brouter] or [osmexp][osmexp]. The input data can also be organized into further subfolders.
 
 Example folder structure for a map that has the layers metro and mainline:
 ```
@@ -81,12 +81,17 @@ input
 ├── layers.json
 └── data
     ├── train
-        ├── lgv_est.geojson
-        └── ringbahn.geojson
+    │  ├── lgv_est.geojson
+    │  └── ringbahn.geojson
     └── tram
-        ├── kusttram.gpx
-        ├── Berlin_M8.gpx
-        └── Vienna_D.gpx
+    	├── Berlin
+        │   ├── M5.gpx
+        │   └── M8.json
+        ├── Vienna
+        │   └──Vienna_D.gpx
+        └── kusttram.gpx
+        
+        
 ```
 
 This file structure could for example be placed in a git repo to manage changes to the map.

--- a/README.md
+++ b/README.md
@@ -1,25 +1,41 @@
 # Streckenkarte
 
-A tool to display maps of lines as vector tiles using leaflet.
-
+A tool to generate vector tiles from input files (.gpx, .geojson or similar) and display them on top of another map using leaflet.
 
 ## Dependencies
-
 * Tippecanoe (requires version 2 or later)
 * ogrmerge (part of gdal-bin in Debian)
 * jq
 
 ## Usage
 
+### Displaying the webpage
 This software is meant to be installed as a hosted installation for
 several maps. This is done by putting the files in the `frontend`
 directory on a web server so they appear as `/common/*`, and then
 creating a directory for each map, with the maps appearing at
 `/$mapname/`. This directory should contain a `strecken.pmtiles`
 containing the vector tiles, as well as a `layers.json` containing
-metadata, and the web server should be configured to display
-`/common/index.html` when accessing `/$mapname/`. This can be achieved
-on nginx with the following snippet:
+metadata.
+
+Example folder structure for a website that hosts two maps:
+```
+map.example.com/
+├── index.html
+└── common
+    ├── map.js
+    ├── style.css
+├── map1
+    ├── layers.json
+    └── strecken.pmtiles
+└── map2
+    ├── layers.json
+    └── strecken.pmtiles
+```
+
+The web server should be configured to display
+`/common/index.html` when accessing `/$mapname/`. 
+This can be done on nginx with the following snippet:
 
 ```Nginx
 location ~ /.+/$ {
@@ -37,23 +53,43 @@ host {
 	file_server
 }
 ```
+### Creating the map tiles using mapbuilder.sh
 
 The `strecken.pmtiles` file is best generated using the
-`mapbuilder.sh` script. Furthermore, exporting maps from umap is
-possible using the `umap-extractor.py` script, which takes care of
-exporting the data as well as the graphical style for each layer. 
+`mapbuilder.sh` script by running
+
+```
+./mapbuilder.sh path/to/input/directory path/to/output/directory
+```
+
 
 A sample git `post-receive` hook is provided to build and deploy the
 map when the map data is pushed.
 
-### Input Data
+#### Input Data
 
-The input data for `strecken.pmtiles` consists of a `data/` folder,
+The input folder for `strecken.pmtiles` consists of a `data/` folder,
 with one subfolder for each layer. In each of these folders, the lines
 to be displayed on the map can be deposited in any format understood
 by [ogrmerge](https://gdal.org/programs/ogrmerge.html), for instance,
 GeoJSON or gpx. The input data can be obtained from OpenStreetMap
 using tools such as [brouter][brouter] or [osmexp][osmexp].
+
+Example folder structure for a map that has the layers metro and mainline:
+```
+input
+├── layers.json
+└── data
+    ├── train
+        ├── lgv_est.geojson
+        └── ringbahn.geojson
+    └── tram
+        ├── kusttram.gpx
+        ├── Berlin_M8.gpx
+        └── Vienna_D.gpx
+```
+
+This file structure could for example be placed in a git repo to manage changes to the map.
 
 #### layers.json
 
@@ -92,6 +128,10 @@ maximum zoom level for which tiles should be rendered, increasing this
 value also increases the size of the `strecken.pmtiles` file. If not
 given explicitly `maxZoom` defaults to 10.
 
+### Extracting from umap
+Furthermore, exporting maps from umap is
+possible using the `umap-extractor.py` script, which takes care of
+exporting the data as well as the graphical style for each layer.
 
 ## Map Editing Mode
 

--- a/scripts/mapbuilder.sh
+++ b/scripts/mapbuilder.sh
@@ -9,12 +9,23 @@ temp=$(mktemp -d)
 zoom=$(jq '.maxZoom // 10' "$1/layers.json")
 
 mkdir "$temp/data"
+IFS=$'\n'
+
 for i in "$1/data/"*
 do	
-	ogrmerge.py -single -o "$temp/$(basename $i).json"  "$i"/* 
+	layername=$(basename $i)
+	echo "Processing layer $layername"
+	mkdir "$temp/$layername"
+		
+	for file in $(find "$1/data/$layername" -type f ); 
+	do
+		echo "Processing file $(basename $file)"
+		cp "$file" "$temp/$layername/$(basename $file)"
+	done
+	
+	ogrmerge.py -single -o "$temp/$layername.json"  "$temp/$layername/"* 
+
 done
-
-
 
 tippecanoe -aN -z"$zoom" -o "$temp/strecken.pmtiles" $temp/*.json
 

--- a/scripts/mapbuilder.sh
+++ b/scripts/mapbuilder.sh
@@ -12,17 +12,18 @@ mkdir "$temp/data"
 IFS=$'\n'
 
 for i in "$1/data/"*
-do	
+do
 	layername=$(basename $i)
 	echo "Processing layer $layername"
 	mkdir "$temp/$layername"
-		
+
 	for file in $(find "$1/data/$layername" -type f ); 
 	do
 		echo "Processing file $(basename $file)"
-		cp "$file" "$temp/$layername/$(basename $file)"
+		hash=$(sha256sum "$file" | cut -f 1 -d " ")
+		cp "$file" "$temp/$layername/$hash"
 	done
-	
+
 	ogrmerge.py -single -o "$temp/$layername.json"  "$temp/$layername/"* 
 
 done


### PR DESCRIPTION
Modified the mapbuilder.sh script so instead of executing ogrmerge on the directory for the layer, it finds all files within that directory and its subdirectories and copies them into a single temporary folder to execute ogrmerge on. That way the files can be organized in subfolders (e.g. one for each cities metro system), but the layer generation can still work as before.

Also the script is a bit more verbose now (echos layer and file names) which I found helpful for debugging both the script itself and my input data when I was using the script. This could be removed again.